### PR TITLE
Add OrdemServico response typing

### DIFF
--- a/src/app/Models/ordem-servico/ordem-servico-service-response.ts
+++ b/src/app/Models/ordem-servico/ordem-servico-service-response.ts
@@ -1,0 +1,5 @@
+import { OrdemServico } from './ordem-servico.model';
+
+export interface OrdemServicoServiceResponse {
+  ordemServicoAtualizada: OrdemServico;
+}

--- a/src/app/modules/ordem-servico/pecas/pecas-ordem-servico.component.ts
+++ b/src/app/modules/ordem-servico/pecas/pecas-ordem-servico.component.ts
@@ -16,6 +16,8 @@ import { CommonModule } from '@angular/common';
 import { FormsModule, NgSelectOption } from '@angular/forms';
 import { OrdemServico } from '../../../Models/ordem-servico/ordem-servico.model';
 import { NgSelectModule } from '@ng-select/ng-select';
+import { RespostaApi } from '../../../Models/reposta-api.model';
+import { OrdemServicoServiceResponse } from '../../../Models/ordem-servico/ordem-servico-service-response';
 
 @Component({
   selector: 'app-pecas-ordem-servico',
@@ -63,7 +65,7 @@ export class PecasOrdemServicoComponent implements OnInit {
   this.novaPeca.valorTotal = this.novaPeca.quantidade * this.novaPeca.valorUnitario;
   this.novaPeca.idOrdemServico = this.ordemServicoId;
   this.pecaService.criarPeca(this.ordemServicoId, this.novaPeca).subscribe({
-    next: (resposta) => {
+    next: (resposta: OrdemServicoServiceResponse) => {
       this.toast.success('Peça adicionada.');
       this.ordemServico = resposta.ordemServicoAtualizada; // <- IMPORTANTE
       this.osAtualizada.emit(resposta.ordemServicoAtualizada);
@@ -77,7 +79,7 @@ export class PecasOrdemServicoComponent implements OnInit {
 
   removerPeca(id: number): void {
     this.pecaService.removerPeca(this.ordemServicoId, id).subscribe({
-      next: (resposta) => {
+      next: (resposta: OrdemServicoServiceResponse) => {
         this.toast.success('Peça removida.');
         this.osAtualizada.emit(resposta.ordemServicoAtualizada);
         this.carregarPecas();

--- a/src/app/modules/ordem-servico/servicos-ordem-servico/servicos-ordem-servico.component.ts
+++ b/src/app/modules/ordem-servico/servicos-ordem-servico/servicos-ordem-servico.component.ts
@@ -7,6 +7,8 @@ import { OrdemServicoServicoService } from '../../../services/ordem-servico/orde
 import { ToastService } from '../../../services/toast.service';
 import { OrdemServicoServico, OrdemServicoServicoCriacaoPayload } from '../../../Models/ordem-servico/ordem-servico-servico';
 import { OrdemServico } from '../../../Models/ordem-servico/ordem-servico.model';
+import { RespostaApi } from '../../../Models/reposta-api.model';
+import { OrdemServicoServiceResponse } from '../../../Models/ordem-servico/ordem-servico-service-response';
 
 
 
@@ -64,30 +66,34 @@ export class ServicosOrdemServicoComponent implements OnInit {
     this.novoServico.idOrdemServico = this.ordemServicoId;
 
     console.log(this.novoServico);
-    this.servicoService.criarServico(this.ordemServicoId, this.novoServico).subscribe({
-      next: (res) => {
+    this.servicoService
+      .criarServico(this.ordemServicoId, this.novoServico)
+      .subscribe({
+        next: (res: RespostaApi<OrdemServicoServiceResponse>) => {
 
-        this.toast.success('Serviço adicionado.');
-        console.log(res.dados.ordemServicoAtualizada);
-        this.osAtualizada.emit(res.dados.ordemServicoAtualizada);
-        this.resetarFormulario();
-        this.carregarServicos();
-      },
-      error: (err) => this.toast.error(err.message)
-    });
+          this.toast.success('Serviço adicionado.');
+          console.log(res.dados.ordemServicoAtualizada);
+          this.osAtualizada.emit(res.dados.ordemServicoAtualizada);
+          this.resetarFormulario();
+          this.carregarServicos();
+        },
+        error: (err) => this.toast.error(err.message),
+      });
   }
 
-   removerServico(id: number): void {
-    this.servicoOsService.removerServico(this.ordemServicoId, id).subscribe({
-      next: (resposta) => {
-        this.toast.success('Serviço removido com sucesso.');
-        // Emite a OS atualizada para o componente pai
-        this.osAtualizada.emit(resposta.ordemServicoAtualizada);
-        this.resetarFormulario();
-        this.carregarServicos(); // Recarrega a lista
-      },
-      error: (err) => this.toast.error(err.message || 'Erro ao remover serviço'),
-    });
+  removerServico(id: number): void {
+    this.servicoOsService
+      .removerServico(this.ordemServicoId, id)
+      .subscribe({
+        next: (resposta: RespostaApi<OrdemServicoServiceResponse>) => {
+          this.toast.success('Serviço removido com sucesso.');
+          this.osAtualizada.emit(resposta.dados.ordemServicoAtualizada);
+          this.resetarFormulario();
+          this.carregarServicos();
+        },
+        error: (err) =>
+          this.toast.error(err.message || 'Erro ao remover serviço'),
+      });
   }
 
   carregarServicos(): void {

--- a/src/app/services/ordem-servico/ordem-servico-servico.service.ts
+++ b/src/app/services/ordem-servico/ordem-servico-servico.service.ts
@@ -4,6 +4,7 @@ import { Observable } from 'rxjs';
 import { environment } from '../../environments/environment';
 import { RespostaApi } from '../../Models/reposta-api.model';
 import { OrdemServicoServico, OrdemServicoServicoAtualizacaoPayload, OrdemServicoServicoCriacaoPayload } from '../../Models/ordem-servico/ordem-servico-servico';
+import { OrdemServicoServiceResponse } from '../../Models/ordem-servico/ordem-servico-service-response';
 import { CrudService } from '../crud.service';
 
 @Injectable({
@@ -21,15 +22,15 @@ export class OrdemServicoServicoService extends CrudService<OrdemServicoServico,
     return this.http.get<RespostaApi<OrdemServicoServico[]>>(`${this.apiUrlBase}/ordens-servico/${ordemServicoId}/servicos`);
   }
 
-  criarServico(ordemServicoId: number, payload: OrdemServicoServicoCriacaoPayload): Observable<RespostaApi<any>> {
-    return this.http.post<RespostaApi<any>>(`${this.apiUrlBase}/ordens-servico/${ordemServicoId}/servicos`, payload);
+  criarServico(ordemServicoId: number, payload: OrdemServicoServicoCriacaoPayload): Observable<RespostaApi<OrdemServicoServiceResponse>> {
+    return this.http.post<RespostaApi<OrdemServicoServiceResponse>>(`${this.apiUrlBase}/ordens-servico/${ordemServicoId}/servicos`, payload);
   }
 
-  atualizarServico(id: number, payload: OrdemServicoServicoAtualizacaoPayload): Observable<RespostaApi<any>> {
-    return this.http.put<RespostaApi<any>>(`${this.apiUrlBase}/ordens-servico/${payload.idOrdemServico}/servicos/${id}`, payload);
+  atualizarServico(id: number, payload: OrdemServicoServicoAtualizacaoPayload): Observable<RespostaApi<OrdemServicoServiceResponse>> {
+    return this.http.put<RespostaApi<OrdemServicoServiceResponse>>(`${this.apiUrlBase}/ordens-servico/${payload.idOrdemServico}/servicos/${id}`, payload);
   }
 
-  removerServico(ordemServicoId: number, id: number): Observable<any> {
-    return this.http.delete<any>(`${this.apiUrlBase}/ordens-servico/${ordemServicoId}/servicos/${id}`);
+  removerServico(ordemServicoId: number, id: number): Observable<RespostaApi<OrdemServicoServiceResponse>> {
+    return this.http.delete<RespostaApi<OrdemServicoServiceResponse>>(`${this.apiUrlBase}/ordens-servico/${ordemServicoId}/servicos/${id}`);
   }
 }


### PR DESCRIPTION
## Summary
- create `OrdemServicoServiceResponse` interface
- type `OrdemServicoServicoService` responses
- use typed response in `ServicosOrdemServicoComponent` and `PecasOrdemServicoComponent`

## Testing
- `npm test` *(fails: nx not found)*

------
https://chatgpt.com/codex/tasks/task_e_68474aa5c13483318907b65a8886eedf